### PR TITLE
option to make diploid dataset

### DIFF
--- a/src/python/cross/build_training_data.py
+++ b/src/python/cross/build_training_data.py
@@ -121,7 +121,7 @@ def include_all_pos(collapsed_matrix, unique_pos, gamete_to_idx, answer_key1, an
     '''
     Adds unlabelled bins to the collapsed matrix with -1 labels
     '''
-    last_bin = min(len(answer_key1), len(answer_key2)) # TODO: make sure this the right length
+    last_bin = min(len(answer_key1), len(answer_key2))
 
     all_pos_matrix = np.zeros((last_bin, collapsed_matrix.shape[1]), dtype=np.int8)
     labels_1 = np.array([gamete_to_idx.get(str(x), -1) for x in answer_key1], dtype=np.int8)


### PR DESCRIPTION
Adds in new parameter --sample-assembly-key to map sample names to one or two assemblies
Create haploid or diploid matrices